### PR TITLE
Make example more effecient?

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ fun main() {
 fun Sheet.customersHeader() {
     val headings = listOf("Id", "Name", "Address", "Age")
 
-    val headingStyle = createCellStyle() {
-        setFont(createFont() {
+    val headingStyle = createCellStyle {
+        setFont(createFont {
             fontName = "IMPACT"
             color = IndexedColors.PINK.index
         })

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ fun main() {
 fun Sheet.customersHeader() {
     val headings = listOf("Id", "Name", "Address", "Age")
 
-    val headingStyle = createCellStyle().apply {
-        setFont(createFont().apply {
+    val headingStyle = createCellStyle() {
+        setFont(createFont() {
             fontName = "IMPACT"
             color = IndexedColors.PINK.index
         })

--- a/src/main/kotlin/excelkt/Elements.kt
+++ b/src/main/kotlin/excelkt/Elements.kt
@@ -22,6 +22,8 @@ class Workbook(
             style = style ?: this.style,
             name = name
         ).apply(init)
+    fun createCellStyle(f: XSSFCellStyle.() -> Unit = { }) = xssfWorkbook.createCellStyle().apply(f)
+    fun createFont(f: XSSFFont.() -> Unit = { }): XSSFFont = xssfWorkbook.createFont().apply(f)
 }
 
 class Sheet(


### PR DESCRIPTION
explicit `apply()` is unnecessary